### PR TITLE
`PrescribedVelocityFields` for updating velocities

### DIFF
--- a/src/OfflineLagrangianFilter/OfflineLagrangianFilter.jl
+++ b/src/OfflineLagrangianFilter/OfflineLagrangianFilter.jl
@@ -57,7 +57,7 @@ end
 Return a flattened `NamedTuple` of the fields in `model.velocities`, `model.tracers`, and any
 auxiliary fields for a `LagrangianFilter` model.
 """
-fields(model::LagrangianFilter) = merge(model.velocities,
+fields(model::LagrangianFilter) = merge((u = model.velocities.u, v = model.velocities.v, w = model.velocities.w),
                                         model.tracers,
                                         model.auxiliary_fields)
 

--- a/src/OfflineLagrangianFilter/compute_lagrangian_filter_tendencies.jl
+++ b/src/OfflineLagrangianFilter/compute_lagrangian_filter_tendencies.jl
@@ -111,7 +111,7 @@ function compute_flux_bc_tendencies!(model::LagrangianFilter)
     arch  = model.architecture
     clock = model.clock
     model_fields = fields(model)
-    prognostic_fields = merge(model.velocities, model.tracers)
+    prognostic_fields = model.tracers
 
     foreach(i -> compute_x_bcs!(Gⁿ[i], prognostic_fields[i], arch, clock, model_fields), 1:length(prognostic_fields))
     foreach(i -> compute_y_bcs!(Gⁿ[i], prognostic_fields[i], arch, clock, model_fields), 1:length(prognostic_fields))

--- a/src/OfflineLagrangianFilter/lagrangian_filter_tendency_kernel_functions.jl
+++ b/src/OfflineLagrangianFilter/lagrangian_filter_tendency_kernel_functions.jl
@@ -48,7 +48,7 @@ velocity components, tracer fields, and precalculated diffusivities where applic
 
     @inbounds c = tracers[tracer_index]
 
-    model_fields = merge(velocities, tracers, auxiliary_fields)
+    model_fields = merge((u = velocities.u, v = velocities.v, w = velocities.w), tracers, auxiliary_fields)
 
 
     total_velocities = with_advective_forcing(forcing, velocities)

--- a/src/OfflineLagrangianFilter/run_offline_lagrangian_filter.jl
+++ b/src/OfflineLagrangianFilter/run_offline_lagrangian_filter.jl
@@ -43,8 +43,10 @@ function run_offline_Lagrangian_filter(config)
     forcing = create_forcing(filtered_vars, config)
     @info "Created forcing for filtered variables"
 
+    velocities = grab_velocities(input_data.velocity_data)
+
     # Define model 
-    model = LagrangianFilter(config.grid; tracers = filtered_vars, auxiliary_fields = original_vars, forcing = forcing, advection=config.advection)
+    model = LagrangianFilter(config.grid; tracers = filtered_vars, velocities, auxiliary_fields = original_vars, forcing = forcing, advection=config.advection)
     @info "Created model"
 
     # We can set initial values to improve the spinup, use the limit freq_c -> \infty
@@ -128,4 +130,12 @@ function run_offline_Lagrangian_filter(config)
         jld2_to_netcdf(config.output_filename, config.output_filename[1:end-5] * ".nc")
     end
 
+end
+
+# Correct this!
+function grab_velocities(velocities::Tuple)
+    u = velocities[1]
+    v = Oceananigans.Fields.ZeroField()
+    w = velocities[2]
+    return PrescribedVelocityFields(; u, v, w)
 end

--- a/src/OfflineLagrangianFilter/update_lagrangian_filter_state.jl
+++ b/src/OfflineLagrangianFilter/update_lagrangian_filter_state.jl
@@ -28,8 +28,7 @@ function update_state!(model::LagrangianFilter, callbacks=[]; compute_tendencies
     update_boundary_conditions!(fields(model), model)
 
     # Fill halos for velocities and tracers
-    fill_halo_regions!(merge(model.velocities, model.tracers), model.clock, fields(model); 
-                       fill_open_bcs = false, async = true)
+    fill_halo_regions!(model.tracers, model.clock, fields(model); fill_open_bcs = false, async = true)
 
     # Compute auxiliary fields
     for aux_field in model.auxiliary_fields

--- a/src/Utils/lagrangian_filter_utils.jl
+++ b/src/Utils/lagrangian_filter_utils.jl
@@ -867,13 +867,13 @@ function update_input_data!(model::AbstractModel, input_data::NamedTuple)
     t = model.clock.time
     
     # Update the velocities
-    kwargs = (; (Symbol(vel_fts.name) => vel_fts[Time(t)] for vel_fts in velocity_timeseries)...)
-    set!(model; kwargs...)          
+    # kwargs = (; (Symbol(vel_fts.name) => vel_fts[Time(t)] for vel_fts in velocity_timeseries)...)
+    # set!(model; kwargs...)          
 
     # We also update the saved original variables to be used for forcing - these are auxiliary fields so need to be set separately
     for original_var_fts in original_var_timeseries
-        set!(getproperty(model.auxiliary_fields, Symbol(original_var_fts.name)), original_var_fts[Time(t)])
-        # halo regions get filled automatically
+        field = getproperty(model.auxiliary_fields, Symbol(original_var_fts.name))
+        parent(field) .= parent(original_var_fts[Time(t)])
     end
 end
 


### PR DESCRIPTION
this PR implements a different approach for updating the velocity fields in the `LagrangianFilter` model.

See issue #2 

todo:
- [x] Remove velocities from `prognostic_fields`
- [ ] remove all `merge(velocities, tracers)` since this will not work with `PrescribedVelocityFields`
- [ ] correct the `input_data` implementation to reflect the new data structure
- [ ] Make sure tests pass